### PR TITLE
Update UPFDeployment pods on a config-map update.

### DIFF
--- a/free5gc-operator/controllers/upfdeployment_controller_test.go
+++ b/free5gc-operator/controllers/upfdeployment_controller_test.go
@@ -464,7 +464,7 @@ func TestCaclculasteStatusReplicaFailure(t *testing.T) {
 func TestFree5gcUPFDeployment(t *testing.T) {
 	log := log.FromContext(context.TODO())
 	upfDeploymentInstance := newUpfDeployInstance("test-upf-deployment")
-	got, err := free5gcUPFDeployment(log, upfDeploymentInstance)
+	got, err := free5gcUPFDeployment(log, "111111", upfDeploymentInstance)
 	if err != nil {
 		t.Errorf("free5gcUPFDeployment() returned unexpected error %v", err)
 	}
@@ -486,6 +486,7 @@ func TestFree5gcUPFDeployment(t *testing.T) {
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
+						"workload.nephio.org/configMapVersion": "111111",
 						"k8s.v1.cni.cncf.io/networks": `[
         {"name": "test-upf-deployment-n3",
          "interface": "N3",


### PR DESCRIPTION
Initial implementation of configuration changes in UPF. [101](https://github.com/nephio-project/nephio/issues/101)
In case of config-map update, we update an Annotation in Spec.Template.Annotations that trigger a deployment rolling update.
For the time being, we update the existing config map rather than creating a new one. The best practice described below is a subject for R2 or further releases.

Per John:
The best practice would be to create separate ConfigMap as they change. Then, you update the ConfigMap that the deployment volume refers to, which automatically does the rolling update.
By doing this, we ensure that the old replica set doesn't pick up the new ConfigMap. So, if the old Pod restarts, it still has the old config.