### PR TITLE
Change interface names to lowercase letter in UPFDeployment.

### DIFF
--- a/controllers/smfdeployment_controller_test.go
+++ b/controllers/smfdeployment_controller_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"html/template"
 	"reflect"
 	"testing"
@@ -89,10 +88,6 @@ func TestGetSMFResourceParams(t *testing.T) {
 		t.Errorf("getSMFResourceParams returned number of replicas = %d, want %d", replicas, 1)
 	}
 
-	// cpuLimit = "100m"
-	// cpuRequest = "100m"
-	// memoryRequest = "128Mi"
-
 	want := &apiv1.ResourceRequirements{
 		Limits: apiv1.ResourceList{
 			"cpu":    resource.MustParse("500m"),
@@ -121,10 +116,6 @@ func TestGetSMFNad(t *testing.T) {
     ]`
 	if got != want {
 		t.Errorf("getSMFNad(%v) returned %v, want %v", smfDeploymentInstance, got, want)
-		fmt.Println("Got:")
-		fmt.Println(got)
-		fmt.Println("Want")
-		fmt.Println(want)
 	}
 }
 
@@ -502,13 +493,6 @@ func TestFree5gcSMFDeployment(t *testing.T) {
 			}, // PodTemplateSpec
 		}, // PodTemplateSpec
 	}
-
-	fmt.Println("Got:")
-	fmt.Println(got)
-	fmt.Println()
-	fmt.Println("Want:")
-	fmt.Println(want)
-	fmt.Println()
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("free5gcSMFDeployment(%v) returned %v, want %v", smfDeploymentInstance, got, want)

--- a/controllers/upfdeployment_controller.go
+++ b/controllers/upfdeployment_controller.go
@@ -107,10 +107,10 @@ func constructNadName(templateName string, suffix string) string {
 func getNad(templateName string, spec *workloadv1alpha1.UPFDeploymentSpec) string {
 	var ret string
 
-	n6CfgSlice := getIntConfigSlice(spec.Interfaces, "N6")
-	n3CfgSlice := getIntConfigSlice(spec.Interfaces, "N3")
-	n4CfgSlice := getIntConfigSlice(spec.Interfaces, "N4")
-	n9CfgSlice := getIntConfigSlice(spec.Interfaces, "N9")
+	n6CfgSlice := getIntConfigSlice(spec.Interfaces, "n6")
+	n3CfgSlice := getIntConfigSlice(spec.Interfaces, "n3")
+	n4CfgSlice := getIntConfigSlice(spec.Interfaces, "n4")
+	n9CfgSlice := getIntConfigSlice(spec.Interfaces, "n9")
 
 	ret = `[`
 	intfMap := map[string][]workloadv1alpha1.InterfaceConfig{
@@ -287,18 +287,18 @@ func free5gcUPFDeployment(log logr.Logger, configMapVersion string, upfDeploy *w
 func free5gcUPFCreateConfigmap(logger logr.Logger, upfDeploy *workloadv1alpha1.UPFDeployment) (*apiv1.ConfigMap, error) {
 	namespace := upfDeploy.ObjectMeta.Namespace
 	instanceName := upfDeploy.ObjectMeta.Name
-	n4IP, err := getIPv4(upfDeploy.Spec.Interfaces, "N4")
+	n4IP, err := getIPv4(upfDeploy.Spec.Interfaces, "n4")
 	if err != nil {
 		log.Log.Info("Interface N4 not found in NFDeployment Spec")
 		return nil, err
 	}
-	n3IP, err := getIPv4(upfDeploy.Spec.Interfaces, "N3")
+	n3IP, err := getIPv4(upfDeploy.Spec.Interfaces, "n3")
 	if err != nil {
 		log.Log.Info("Interface N3 not found in NFDeployment Spec")
 		return nil, err
 	}
 
-	n6IP, err := getIntConfig(upfDeploy.Spec.Interfaces, "N6")
+	n6IP, err := getIntConfig(upfDeploy.Spec.Interfaces, "n6")
 	if err != nil {
 		log.Log.Info("Interface N6 not found in NFDeployment Spec")
 		return nil, err
@@ -309,7 +309,7 @@ func free5gcUPFCreateConfigmap(logger logr.Logger, upfDeploy *workloadv1alpha1.U
 	upfcfgStruct.GTPU_IP = n3IP
 	upfcfgStruct.N6gw = string(*n6IP.IPv4.Gateway)
 
-	n6Instances, ok := getNetworkInsance(upfDeploy.Spec, "N6")
+	n6Instances, ok := getNetworkInsance(upfDeploy.Spec, "n6")
 	if !ok {
 		log.Log.Info("No N6 interface in NFDeployment Spec.")
 		return nil, errors.New("No N6 intefaces in NFDeployment Spec.")

--- a/controllers/upfdeployment_controller_test.go
+++ b/controllers/upfdeployment_controller_test.go
@@ -38,7 +38,7 @@ func newNxInterface(name string) workloadv1alpha1.InterfaceConfig {
 	case "n3":
 		gw := "10.10.10.1"
 		n3int := workloadv1alpha1.InterfaceConfig{
-			Name: "N3",
+			Name: "n3",
 			IPv4: &workloadv1alpha1.IPv4{
 				Address: "10.10.10.10/24",
 				Gateway: &gw,
@@ -49,7 +49,7 @@ func newNxInterface(name string) workloadv1alpha1.InterfaceConfig {
 	case "n4":
 		gw := "10.10.11.1"
 		n4int := workloadv1alpha1.InterfaceConfig{
-			Name: "N4",
+			Name: "n4",
 			IPv4: &workloadv1alpha1.IPv4{
 				Address: "10.10.11.10/24",
 				Gateway: &gw,
@@ -60,7 +60,7 @@ func newNxInterface(name string) workloadv1alpha1.InterfaceConfig {
 	case "n6":
 		gw := "10.10.12.1"
 		n6int := workloadv1alpha1.InterfaceConfig{
-			Name: "N6",
+			Name: "n6",
 			IPv4: &workloadv1alpha1.IPv4{
 				Address: "10.10.12.10/24",
 				Gateway: &gw,
@@ -101,7 +101,7 @@ func newUpfDeployInstance(name string) *workloadv1alpha1.UPFDeployment {
 					{
 						Name: "vpc-internet",
 						Interfaces: []string{
-							"N6",
+							"n6",
 						},
 						DataNetworks: []workloadv1alpha1.DataNetwork{
 							{
@@ -172,17 +172,17 @@ func TestGetNad(t *testing.T) {
 
 	want := `[
         {"name": "test-upf-deployment-n3",
-         "interface": "N3",
+         "interface": "n3",
          "ips": ["10.10.10.10/24"],
          "gateways": ["10.10.10.1"]
         },
         {"name": "test-upf-deployment-n4",
-         "interface": "N4",
+         "interface": "n4",
          "ips": ["10.10.11.10/24"],
          "gateways": ["10.10.11.1"]
         },
         {"name": "test-upf-deployment-n6",
-         "interface": "N6",
+         "interface": "n6",
          "ips": ["10.10.12.10/24"],
          "gateways": ["10.10.12.1"]
         }
@@ -201,15 +201,15 @@ func TestFree5gcUPFCreateConfigmap(t *testing.T) {
 		t.Errorf("free5gcUPFCreateConfigmap() returned unexpected error %v", err)
 	}
 
-	n4IP, _ := getIPv4(upfDeploymentInstance.Spec.Interfaces, "N4")
-	n3IP, _ := getIPv4(upfDeploymentInstance.Spec.Interfaces, "N3")
-	n6IP, _ := getIntConfig(upfDeploymentInstance.Spec.Interfaces, "N6")
+	n4IP, _ := getIPv4(upfDeploymentInstance.Spec.Interfaces, "n4")
+	n3IP, _ := getIPv4(upfDeploymentInstance.Spec.Interfaces, "n3")
+	n6IP, _ := getIntConfig(upfDeploymentInstance.Spec.Interfaces, "n6")
 
 	upfcfgStruct := UPFcfgStruct{}
 	upfcfgStruct.PFCP_IP = n4IP
 	upfcfgStruct.GTPU_IP = n3IP
 	upfcfgStruct.N6gw = *n6IP.IPv4.Gateway
-	n6Cfg, _ := getNetworkInsance(upfDeploymentInstance.Spec, "N6")
+	n6Cfg, _ := getNetworkInsance(upfDeploymentInstance.Spec, "n6")
 	upfcfgStruct.N6cfg = n6Cfg
 
 	upfcfgTemplate := template.New("UPFCfg")
@@ -489,17 +489,17 @@ func TestFree5gcUPFDeployment(t *testing.T) {
 						"workload.nephio.org/configMapVersion": "111111",
 						"k8s.v1.cni.cncf.io/networks": `[
         {"name": "test-upf-deployment-n3",
-         "interface": "N3",
+         "interface": "n3",
          "ips": ["10.10.10.10/24"],
          "gateways": ["10.10.10.1"]
         },
         {"name": "test-upf-deployment-n4",
-         "interface": "N4",
+         "interface": "n4",
          "ips": ["10.10.11.10/24"],
          "gateways": ["10.10.11.1"]
         },
         {"name": "test-upf-deployment-n6",
-         "interface": "N6",
+         "interface": "n6",
          "ips": ["10.10.12.10/24"],
          "gateways": ["10.10.12.1"]
         }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -26,7 +26,7 @@ import (
 func TestGetIntConfigSlice(t *testing.T) {
 	gw1 := "10.10.12.1"
 	intf1 := workloadv1alpha1.InterfaceConfig{
-		Name: "N4",
+		Name: "n4",
 		IPv4: &workloadv1alpha1.IPv4{
 			Address: "10.10.12.10/24",
 			Gateway: &gw1,
@@ -34,7 +34,7 @@ func TestGetIntConfigSlice(t *testing.T) {
 	}
 	gw2 := "10.10.11.1"
 	intf2 := workloadv1alpha1.InterfaceConfig{
-		Name: "N4",
+		Name: "n4",
 		IPv4: &workloadv1alpha1.IPv4{
 			Address: "10.10.11.10/24",
 			Gateway: &gw2,
@@ -44,16 +44,16 @@ func TestGetIntConfigSlice(t *testing.T) {
 		intf1, intf2,
 	}
 
-	got := getIntConfigSlice(interfaces, "N4")
+	got := getIntConfigSlice(interfaces, "n4")
 	if !reflect.DeepEqual(got, interfaces) {
-		t.Errorf("getIntConfigSlice(%v, \"N4\") returned %v, want %v", interfaces, got, interfaces)
+		t.Errorf("getIntConfigSlice(%v, \"n4\") returned %v, want %v", interfaces, got, interfaces)
 	}
 }
 
 func TestGetIntConfigSliceEmpty(t *testing.T) {
 	gw1 := "10.10.12.1"
 	intf1 := workloadv1alpha1.InterfaceConfig{
-		Name: "N4",
+		Name: "n4",
 		IPv4: &workloadv1alpha1.IPv4{
 			Address: "10.10.12.10/24",
 			Gateway: &gw1,
@@ -64,16 +64,16 @@ func TestGetIntConfigSliceEmpty(t *testing.T) {
 	}
 
 	want := []workloadv1alpha1.InterfaceConfig{}
-	got := getIntConfigSlice(interfaces, "N6")
+	got := getIntConfigSlice(interfaces, "n6")
 	if len(got) != 0 {
-		t.Errorf("getIntConfigSlice(%v, \"N6\") returned %v, want %v", interfaces, got, want)
+		t.Errorf("getIntConfigSlice(%v, \"n6\") returned %v, want %v", interfaces, got, want)
 	}
 }
 
 func TestGetIntConfig(t *testing.T) {
 	gw := "10.10.12.1"
 	intf := workloadv1alpha1.InterfaceConfig{
-		Name: "N4",
+		Name: "n4",
 		IPv4: &workloadv1alpha1.IPv4{
 			Address: "10.10.12.10/24",
 			Gateway: &gw,
@@ -82,18 +82,18 @@ func TestGetIntConfig(t *testing.T) {
 	interfaces := []workloadv1alpha1.InterfaceConfig{
 		intf,
 	}
-	got, _ := getIntConfig(interfaces, "N4")
+	got, _ := getIntConfig(interfaces, "n4")
 	want := "10.10.12.10/24"
 
 	if !reflect.DeepEqual(*got, intf) {
-		t.Errorf("getIntConfig(%v, \"N4\") returned %+v, want %v", interfaces, got, want)
+		t.Errorf("getIntConfig(%v, \"n4\") returned %+v, want %v", interfaces, got, want)
 	}
 }
 
 func TestGetIntConfigNotFound(t *testing.T) {
 	gw := "10.10.12.1"
 	intf := workloadv1alpha1.InterfaceConfig{
-		Name: "N4",
+		Name: "n4",
 		IPv4: &workloadv1alpha1.IPv4{
 			Address: "10.10.12.10/24",
 			Gateway: &gw,
@@ -102,17 +102,17 @@ func TestGetIntConfigNotFound(t *testing.T) {
 	interfaces := []workloadv1alpha1.InterfaceConfig{
 		intf,
 	}
-	got, _ := getIntConfig(interfaces, "N4")
+	got, _ := getIntConfig(interfaces, "n4")
 
 	if got == nil {
-		t.Errorf("getIntConfig(%v, \"N3\") returned %v, want %v", interfaces, got, "")
+		t.Errorf("getIntConfig(%v, \"n3\") returned %v, want %v", interfaces, got, "")
 	}
 }
 
 func TestGetIPv4(t *testing.T) {
 	gw := "10.10.12.1"
 	intf := workloadv1alpha1.InterfaceConfig{
-		Name: "N4",
+		Name: "n4",
 		IPv4: &workloadv1alpha1.IPv4{
 			Address: "10.10.12.10/24",
 			Gateway: &gw,
@@ -121,18 +121,18 @@ func TestGetIPv4(t *testing.T) {
 	interfaces := []workloadv1alpha1.InterfaceConfig{
 		intf,
 	}
-	got, _ := getIPv4(interfaces, "N4")
+	got, _ := getIPv4(interfaces, "n4")
 	want := "10.10.12.10"
 
 	if got != want {
-		t.Errorf("getIPv4(%v, \"N4\") returned %v, want %v", interfaces, got, want)
+		t.Errorf("getIPv4(%v, \"n4\") returned %v, want %v", interfaces, got, want)
 	}
 }
 
 func TestGetIPv4NotFound(t *testing.T) {
 	gw := "10.10.12.1"
 	intf := workloadv1alpha1.InterfaceConfig{
-		Name: "N4",
+		Name: "n4",
 		IPv4: &workloadv1alpha1.IPv4{
 			Address: "10.10.12.10/24",
 			Gateway: &gw,
@@ -141,10 +141,10 @@ func TestGetIPv4NotFound(t *testing.T) {
 	interfaces := []workloadv1alpha1.InterfaceConfig{
 		intf,
 	}
-	got, _ := getIPv4(interfaces, "N3")
+	got, _ := getIPv4(interfaces, "n3")
 
 	if got != "" {
-		t.Errorf("getIPv4(%v, \"N3\") returned %v, want %v", interfaces, got, "")
+		t.Errorf("getIPv4(%v, \"n3\") returned %v, want %v", interfaces, got, "")
 	}
 }
 
@@ -155,7 +155,7 @@ func TestGetNetworkInsance(t *testing.T) {
 	ns := workloadv1alpha1.NetworkInstance{
 		Name: "vpc-internet",
 		Interfaces: []string{
-			"N6",
+			"n6",
 		},
 		DataNetworks: []workloadv1alpha1.DataNetwork{
 			{
@@ -174,22 +174,22 @@ func TestGetNetworkInsance(t *testing.T) {
 		ns,
 	}
 
-	got, b := getNetworkInsance(upfDeployment.Spec, "N6")
+	got, b := getNetworkInsance(upfDeployment.Spec, "n6")
 
 	if b != true {
-		t.Errorf("getNetworkInstance(%+v, \"N6\") returned %v, want %v", upfDeployment.Spec, got, want)
+		t.Errorf("getNetworkInstance(%+v, \"n6\") returned %v, want %v", upfDeployment.Spec, got, want)
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("getNetworkInstance(%+v, \"N6\") returned %+v, want %+v", upfDeployment.Spec, got, want)
+		t.Errorf("getNetworkInstance(%+v, \"n6\") returned %+v, want %+v", upfDeployment.Spec, got, want)
 	}
 }
 
 func TestGetNetworkInsanceNoInstance(t *testing.T) {
 	upfDeployment := newUpfDeployInstance("test-upf-deployment")
 
-	_, b := getNetworkInsance(upfDeployment.Spec, "N6-1")
+	_, b := getNetworkInsance(upfDeployment.Spec, "n6-1")
 
 	if b != false {
-		t.Errorf("getNetworkInstance(%+v, \"N6-1\") returned %v, want %v", upfDeployment.Spec, b, false)
+		t.Errorf("getNetworkInstance(%+v, \"n6-1\") returned %v, want %v", upfDeployment.Spec, b, false)
 	}
 }

--- a/test/upfdeploy.yaml
+++ b/test/upfdeploy.yaml
@@ -10,17 +10,17 @@ spec:
     maxUplinkThroughput: 3G
     maxDownlinkThroughput: 1G
   interfaces:
-    - name: N3
+    - name: n3
       ipv4:
         address: 13.0.0.2/24
         gateway: 13.0.0.1
       vlanID: 13
-    - name: N4
+    - name: n4
       ipv4:
         address: 14.0.0.2/24
         gateway: 14.0.0.1
       vlanID: 14
-    - name: N6
+    - name: n6
       ipv4:
         address: 16.0.0.2/24
         gateway: 16.0.0.1
@@ -28,13 +28,13 @@ spec:
   networkInstances:
     - name: vpc-ran
       interfaces:
-        - N3
+        - n3
     - name: vpc-internal
       interfaces:
-        - N4
+        - n4
     - name: vpc-internet
       interfaces:
-        - N6
+        - n6
       dataNetworks:
         - name: internet
           pool:

--- a/test/upfdeploy2.yaml
+++ b/test/upfdeploy2.yaml
@@ -10,17 +10,17 @@ spec:
     maxUplinkThroughput: 10G
     maxDownlinkThroughput: 10G
   interfaces:
-    - name: N3
+    - name: n3
       ipv4:
         address: 13.1.0.2/24
         gateway: 13.1.0.1
       vlanID: 13
-    - name: N4
+    - name: n4
       ipv4:
         address: 14.1.0.2/24
         gateway: 14.1.0.1
       vlanID: 14
-    - name: N6
+    - name: n6
       ipv4:
         address: 16.1.0.2/24
         gateway: 16.1.0.1
@@ -28,13 +28,13 @@ spec:
   networkInstances:
     - name: vpc-ran
       interfaces:
-        - N3
+        - n3
     - name: vpc-internal
       interfaces:
-        - N4
+        - n4
     - name: vpc-internet
       interfaces:
-        - N6
+        - n6
       dataNetworks:
         - name: internet
           pool:


### PR DESCRIPTION
Housekeeping. Changing interface names in UPFDeployment to lowercase letters to align with AMF/SMFDeployment and pkg specialization.