### PR TITLE
Change Spec.Provider to free5gc.io

### DIFF
--- a/controllers/nf/reconciler.go
+++ b/controllers/nf/reconciler.go
@@ -104,6 +104,7 @@ func (r *NFDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		amfresult, _ := amfReconciler.Reconcile(ctx, req)
 		return amfresult, nil
 	default:
+		log.Info("NFDeployment NOT for free5gc", "nfDeployment.Spec.Provider", nfDeployment.Spec.Provider)
 		return reconcile.Result{}, nil
 	}
 }

--- a/controllers/nf/reconciler.go
+++ b/controllers/nf/reconciler.go
@@ -94,13 +94,13 @@ func (r *NFDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	switch nfDeployment.Spec.Provider {
-	case "upf.free5gc.nephio.org":
+	case "upf.free5gc.io":
 		upfresult, _ := upfReconciler.Reconcile(ctx, req)
 		return upfresult, nil
-	case "smf.free5gc.nephio.org":
+	case "smf.free5gc.io":
 		smfresult, _ := smfReconciler.Reconcile(ctx, req)
 		return smfresult, nil
-	case "amf.free5gc.nephio.org":
+	case "amf.free5gc.io":
 		amfresult, _ := amfReconciler.Reconcile(ctx, req)
 		return amfresult, nil
 	default:


### PR DESCRIPTION
R2 functional testing reveals that management cluster sends `free5gc.io` as suffix for Spec.Provider while the operator expects `free5gc.nephio.org`. Making operator conforms to management cluster.